### PR TITLE
Show related accounts in `get` request

### DIFF
--- a/lib/bankAccount/accounts.ex
+++ b/lib/bankAccount/accounts.ex
@@ -9,6 +9,21 @@ defmodule BankAccount.Accounts do
   alias BankAccount.Accounts.Account
 
   @doc """
+  Gets a single account.
+
+  Returns nil if the Account does not exist.
+
+  ## Examples
+
+      iex> get_account(1)
+      %Account{}
+
+      iex> get_account_cpf(456)
+      nil
+  """
+  def get_account(id), do: Account |> Repo.get(id) |> Repo.preload([:accounts])
+
+  @doc """
   Gets a single account by cpf.
 
   Returns nil if the Account does not exist.

--- a/lib/bankAccount_web/controllers/account_controller.ex
+++ b/lib/bankAccount_web/controllers/account_controller.ex
@@ -19,7 +19,7 @@ defmodule BankAccountWeb.AccountController do
         conn
         |> put_status(:created)
         |> put_resp_header("location", Routes.account_path(conn, :show, account))
-        |> render("show.json", account: account)
+        |> render("show.json", %{account: account, message: get_message(account)})
       end
     else
       account = %Account{} ->
@@ -36,7 +36,13 @@ defmodule BankAccountWeb.AccountController do
   defp update(conn, %Account{} = account, account_params) do
     with {:ok, %Account{} = account} <-
            Accounts.update_account(account, Map.delete(account_params, :cpf)) do
-      render(conn, "show.json", account: account)
+      render(conn, "show.json", %{account: account, message: get_message(account)})
     end
   end
+
+  defp get_message(%{status: "completed", referral_code: referral_code}),
+    do: "Seus dados estão completos. Utilize o código #{referral_code} para convidar seus amigos."
+
+  defp get_message(%{status: "pending"}),
+    do: "Dados salvos! Envie as informações que estão faltando para finalizar o cadastro."
 end

--- a/lib/bankAccount_web/controllers/account_controller.ex
+++ b/lib/bankAccount_web/controllers/account_controller.ex
@@ -28,13 +28,9 @@ defmodule BankAccountWeb.AccountController do
     end
   end
 
-  def show(conn, %{"cpf" => cpf}) do
-    cpf =
-      %Cpf{number: cpf}
-      |> Brcpfcnpj.cpf_format()
-
-    account = Accounts.get_account_by_cpf(cpf)
-    render(conn, "show.json", account: account)
+  def show(conn, %{"id" => id}) do
+    account = Accounts.get_account(id)
+    render(conn, "show_with_relateds.json", account: account)
   end
 
   defp update(conn, %Account{} = account, account_params) do

--- a/lib/bankAccount_web/router.ex
+++ b/lib/bankAccount_web/router.ex
@@ -8,7 +8,7 @@ defmodule BankAccountWeb.Router do
   scope "/api", BankAccountWeb do
     pipe_through :api
     resources "/accounts", AccountController, only: [:create]
-    get "/accounts/:cpf", AccountController, :show
+    get "/accounts/:id", AccountController, :show
   end
 
   # Enables LiveDashboard only for development

--- a/lib/bankAccount_web/views/account_view.ex
+++ b/lib/bankAccount_web/views/account_view.ex
@@ -6,8 +6,38 @@ defmodule BankAccountWeb.AccountView do
     %{data: render_one(account, AccountView, "account.json")}
   end
 
+  def render("show_with_relateds.json", %{account: account}) do
+    %{data: render_one(account, AccountView, "related_accounts.json")}
+  end
+
+  def render("related_accounts.json", %{account: account}) do
+    Map.put(account_json(account), :accounts_related, render_related_accounts(account))
+  end
+
   def render("account.json", %{account: account}) do
+    account_json(account)
+  end
+
+  def render("related_account.json", %{account: %{id: id, name: name}}) do
+    %{id: id, name: name}
+  end
+
+  def render_related_accounts(account) do
+    case account.status do
+      "completed" ->
+        render_many(account.accounts, AccountView, "related_account.json")
+
+      "pending" ->
+        %{message: message(account)}
+    end
+  end
+
+  defp message(%{status: "pending"}),
+    do: "Funcionalidade disponível apenas para usuários que completaram o cadastro"
+
+  defp account_json(account) do
     %{
+      id: account.id,
       name: account.name,
       email: account.email,
       cpf: account.cpf,

--- a/lib/bankAccount_web/views/account_view.ex
+++ b/lib/bankAccount_web/views/account_view.ex
@@ -2,8 +2,8 @@ defmodule BankAccountWeb.AccountView do
   use BankAccountWeb, :view
   alias BankAccountWeb.AccountView
 
-  def render("show.json", %{account: account}) do
-    %{data: render_one(account, AccountView, "account.json")}
+  def render("show.json", %{account: account, message: message}) do
+    %{data: render_one(account, AccountView, "account.json"), message: message}
   end
 
   def render("show_with_relateds.json", %{account: account}) do

--- a/test/bankAccount/accounts_test.exs
+++ b/test/bankAccount/accounts_test.exs
@@ -95,6 +95,13 @@ defmodule BankAccount.AccountsTest do
       assert account.parent_id === referrer_account.id
     end
 
+    test "create_account/1 with invalid referral_code and returs error changeset", %{
+      account: _referrer_account
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.create_account(string_params_for(:account, referral_code: "12345678"))
+    end
+
     test "create_account/1 with invalid cpf and returns error changeset" do
       assert {:error, %Ecto.Changeset{}} =
                Accounts.create_account(string_params_for(:account, cpf: "859.653.930-17"))
@@ -139,6 +146,19 @@ defmodule BankAccount.AccountsTest do
                })
 
       assert account.parent_id == referrer_account.id
+    end
+
+    test "update_account/1 with invalid referral_code returns error changeset", %{
+      account: _referrer_account
+    } do
+      {:ok, account} = Accounts.create_account(string_params_for(:account, email: nil))
+
+      assert account.status == "pending"
+
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.update_account(account, %{
+                 "referral_code" => "12345678"
+               })
     end
 
     test "update_account/2 with invalid email returns error changeset", %{account: account} do

--- a/test/bankAccount/accounts_test.exs
+++ b/test/bankAccount/accounts_test.exs
@@ -133,7 +133,7 @@ defmodule BankAccount.AccountsTest do
       assert account.state == @update_attrs["state"]
     end
 
-    test "update_account/1 with valid data and referral_code creates a account", %{
+    test "update_account/2 with valid data and referral_code creates a account", %{
       account: referrer_account
     } do
       {:ok, account} = Accounts.create_account(string_params_for(:account, email: nil))
@@ -148,7 +148,7 @@ defmodule BankAccount.AccountsTest do
       assert account.parent_id == referrer_account.id
     end
 
-    test "update_account/1 with invalid referral_code returns error changeset", %{
+    test "update_account/2 with invalid referral_code returns error changeset", %{
       account: _referrer_account
     } do
       {:ok, account} = Accounts.create_account(string_params_for(:account, email: nil))
@@ -159,6 +159,19 @@ defmodule BankAccount.AccountsTest do
                Accounts.update_account(account, %{
                  "referral_code" => "12345678"
                })
+    end
+
+    test "update_account/2 trying update an existing referral_code", %{account: referrer_account} do
+      {:ok, account} =
+        Accounts.create_account(
+          string_params_for(:account, referral_code: referrer_account.referral_code)
+        )
+
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.update_account(
+                 account,
+                 %{"referral_code" => "AS1ETQ4H"}
+               )
     end
 
     test "update_account/2 with invalid email returns error changeset", %{account: account} do

--- a/test/bankAccount/accounts_test.exs
+++ b/test/bankAccount/accounts_test.exs
@@ -17,6 +17,24 @@ defmodule BankAccount.AccountsTest do
       {:ok, account: account}
     end
 
+    test "get_account/1 returns the account", %{account: account} do
+      returnedAccount = Accounts.get_account(account.id)
+
+      assert account.birth_date == returnedAccount.birth_date
+      assert account.city == returnedAccount.city
+      assert account.country == returnedAccount.country
+      assert account.cpf == returnedAccount.cpf
+      assert account.email == returnedAccount.email
+      assert account.gender == returnedAccount.gender
+      assert account.name == returnedAccount.name
+      assert account.referral_code == returnedAccount.referral_code
+      assert account.state == returnedAccount.state
+    end
+
+    test "get_account/1 returns nil when id not exits" do
+      assert nil == Accounts.get_account(12_315_324)
+    end
+
     test "get_account_by_cpf/1 returns the account with given cpf", %{account: account} do
       returnedAccount = Accounts.get_account_by_cpf(account.cpf)
 

--- a/test/bankAccount_web/controllers/account_controller_test.exs
+++ b/test/bankAccount_web/controllers/account_controller_test.exs
@@ -26,9 +26,9 @@ defmodule BankAccountWeb.AccountControllerTest do
   describe "create account" do
     test "renders account when data is valid and all fields were informed ", %{conn: conn} do
       conn = post(conn, Routes.account_path(conn, :create), account: @create_attrs)
-      assert %{"cpf" => cpf} = json_response(conn, 201)["data"]
+      assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, Routes.account_path(conn, :show, cpf))
+      conn = get(conn, Routes.account_path(conn, :show, id))
 
       response_account = json_response(conn, 200)["data"]
       assert response_account["birth_date"] == @create_attrs["birth_date"]
@@ -46,9 +46,9 @@ defmodule BankAccountWeb.AccountControllerTest do
     test "renders account when data is valid and fields are incompleted ", %{conn: conn} do
       conn = post(conn, Routes.account_path(conn, :create), account: @incomplete_attrs)
 
-      assert %{"cpf" => cpf} = json_response(conn, 201)["data"]
+      assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, Routes.account_path(conn, :show, cpf))
+      conn = get(conn, Routes.account_path(conn, :show, id))
 
       response_account = json_response(conn, 200)["data"]
       assert response_account["birth_date"] == @incomplete_attrs["birth_date"]
@@ -68,9 +68,9 @@ defmodule BankAccountWeb.AccountControllerTest do
 
       conn = post(conn, Routes.account_path(conn, :create), account: attrs_with_referral)
 
-      assert %{"cpf" => cpf} = json_response(conn, 201)["data"]
+      assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, Routes.account_path(conn, :show, cpf))
+      conn = get(conn, Routes.account_path(conn, :show, id))
 
       response_account = json_response(conn, 200)["data"]
 
@@ -85,7 +85,7 @@ defmodule BankAccountWeb.AccountControllerTest do
       assert response_account["referral_code"] != nil
     end
 
-    test "updating a existing account when incompleted data", %{conn: conn} do
+    test "update account when incompleted data", %{conn: conn} do
       Accounts.create_account(@incomplete_attrs)
 
       conn =
@@ -93,9 +93,9 @@ defmodule BankAccountWeb.AccountControllerTest do
           account: %{cpf: @incomplete_attrs["cpf"], name: "Marcos Vinicius"}
         )
 
-      assert %{"cpf" => cpf} = json_response(conn, 200)["data"]
+      assert %{"id" => id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, Routes.account_path(conn, :show, cpf))
+      conn = get(conn, Routes.account_path(conn, :show, id))
 
       response_account = json_response(conn, 200)["data"]
       assert response_account["birth_date"] == @incomplete_attrs["birth_date"]
@@ -121,9 +121,9 @@ defmodule BankAccountWeb.AccountControllerTest do
 
       conn = post(conn, Routes.account_path(conn, :create), account: attrs_with_referral)
 
-      assert %{"cpf" => cpf} = json_response(conn, 200)["data"]
+      assert %{"id" => id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, Routes.account_path(conn, :show, cpf))
+      conn = get(conn, Routes.account_path(conn, :show, id))
 
       response_account = json_response(conn, 200)["data"]
 
@@ -173,9 +173,9 @@ defmodule BankAccountWeb.AccountControllerTest do
   end
 
   describe "show account" do
-    test "renders account when cpf is valid", %{conn: conn} do
-      {:ok, _account} = Accounts.create_account(@create_attrs)
-      conn = get(conn, Routes.account_path(conn, :show, @create_attrs["cpf"]))
+    test "renders account", %{conn: conn} do
+      {:ok, account} = Accounts.create_account(@create_attrs)
+      conn = get(conn, Routes.account_path(conn, :show, account.id))
       response_account = json_response(conn, 200)["data"]
       assert response_account["birth_date"] == @create_attrs["birth_date"]
       assert response_account["city"] == @create_attrs["city"]
@@ -188,9 +188,9 @@ defmodule BankAccountWeb.AccountControllerTest do
       assert response_account["status"] == "completed"
     end
 
-    test "renders error when cpf doesn't exist", %{conn: conn} do
+    test "renders error when id doesn't exist", %{conn: conn} do
       {:ok, _account} = Accounts.create_account(@create_attrs)
-      conn = get(conn, Routes.account_path(conn, :show, "111.111.111-11"))
+      conn = get(conn, Routes.account_path(conn, :show, 12391))
       assert json_response(conn, 200)["data"] == nil
     end
   end

--- a/test/bankAccount_web/controllers/account_controller_test.exs
+++ b/test/bankAccount_web/controllers/account_controller_test.exs
@@ -139,10 +139,30 @@ defmodule BankAccountWeb.AccountControllerTest do
       assert response_account["referral_code"] != nil
     end
 
+    test "update account return error when referral_code is invalid", %{conn: conn} do
+      Accounts.create_account(@incomplete_attrs)
+
+      conn =
+        post(conn, Routes.account_path(conn, :create),
+          account: string_params_for(:account, referral_code: "11111111")
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
     test "renders errors when cpf is invalid", %{conn: conn} do
       conn =
         post(conn, Routes.account_path(conn, :create),
           account: string_params_for(:account, cpf: "315.694.100-04")
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders errors when referral_code is invalid", %{conn: conn} do
+      conn =
+        post(conn, Routes.account_path(conn, :create),
+          account: string_params_for(:account, referral_code: "11111111")
         )
 
       assert json_response(conn, 422)["errors"] != %{}


### PR DESCRIPTION
- [x] Add option to get accounts by `id`;
- [x] Validate if referral_account is valid before add `referrer_account` in new account;
- [x] Validate in update account if does not exist `referrer_account` saved;
- [x] Add success messages and show `related_accounts` in json returns